### PR TITLE
Add Twitter and Facebook metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Startup Slam is a one day series of technical workshops hosted by leaders in the Victoria startup community. Come out and learn what programming for a startup is actually like!">
   <meta name="author" content="">
+  
+  <!-- TWITTER CARD --> 
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Startup Slam">
+  <meta name="twitter:description" content="Startup Slam is a one day series of technical workshops hosted by leaders in the Victoria startup community. Come out and learn what programming for a startup is actually like!">
+  <meta name="twitter:image" content="/static/img/logo-startupslam.png">
+  
+  <!-- FACEBOOK SHARING -->
+  <meta property="og:url" content="http://www.startupslam.io/" />
+  <meta property="og:title" content="Startup Slam" />
+  <meta property="og:description" content="Startup Slam is a one day series of technical workshops hosted by leaders in the Victoria startup community. Come out and learn what programming for a startup is actually like!" />
+  <meta property="og:image" content="/static/img/logo-startupslam.png" />
+  
   <link rel="icon" href="/static/img/favicon.png">
   <title>Startup Slam</title>
 


### PR DESCRIPTION
Facebook and Twitter metatags are necessary if you want to control what it looks like when you share the page. Right now when I share it on Facebook, the image that gets scraped is the Referral SaaSquatch logo, when it might make more sense to show the Startup Slam logo:

![screen shot 2016-09-07 at 9 52 02 pm](https://cloud.githubusercontent.com/assets/5976978/18338090/13942666-754b-11e6-95e0-84ffa5e0f8f5.png)

https://developers.facebook.com/tools/debug/sharing/?q=http%3A%2F%2Fwww.startupslam.io%2F

Also, the favicon is missing at `/static/img/favicon.png`
